### PR TITLE
Change nav styles and add link-color mixin

### DIFF
--- a/source/assets/stylesheets/_global.scss
+++ b/source/assets/stylesheets/_global.scss
@@ -1,3 +1,17 @@
+// Mixins
+
+@mixin link-color ($base-color) {
+  a {
+    color: $base-color;
+
+    &:active,
+    &:focus,
+    &:hover {
+      color: transparentize($base-color, 0.65);
+    }
+  }
+}
+
 // scss-lint:disable SingleLinePerSelector
 
 html { min-height: 100vh; }
@@ -26,11 +40,11 @@ html { min-height: 100vh; }
   }
 
   @include media($medium-screen-up) {
-    p, ol, ul {font-size: $base-font-size * 1.4;}
+    p, ol, ul { font-size: $base-font-size * 1.4; }
   }
-  
+
   @include media($large-screen-up) {
-    p, ol, ul {font-size: $base-font-size * 1.6;}
+    p, ol, ul { font-size: $base-font-size * 1.6; }
   }
 }
 

--- a/source/assets/stylesheets/_nav_sidebar.scss
+++ b/source/assets/stylesheets/_nav_sidebar.scss
@@ -1,10 +1,9 @@
 $sliding-panel-position: "left";        // "left" or "right"
-$sliding-panel-bg-color: $medium-gray;
 $sliding-panel-width: 20rem;
 $sliding-panel-z-index: 99999;
 $sliding-panel-border-color: $dark-gray;
-$sliding-panel-background: lighten($sliding-panel-border-color, 5%);
-$sliding-panel-color: darken(#FFF, 25%);
+$sliding-panel-background: shade($blue, 25%);
+$sliding-panel-color: #fff;
 $sliding-panel-border: 1px solid $sliding-panel-border-color;
 $sliding-panel-color-hover: #fff;
 $sliding-panel-background-focus: lighten($sliding-panel-background, 5%);
@@ -15,6 +14,7 @@ $sliding-panel-fade-screen-bg: #000;
   @include size(100% 100%);
   @include transform(translateX(-100%));
   @include transition(all 0.1s ease-in-out);
+  @include link-color($sliding-panel-color);
 
   background-color: $sliding-panel-background;
   color: $sliding-panel-color;
@@ -40,16 +40,6 @@ $sliding-panel-fade-screen-bg: #000;
 
   &.visible {
     @include transform(translateX(0));
-  }
-
-  // link styles
-  a {
-    color: $sliding-panel-color;
-
-    &:hover,
-    &:active {
-      color: $sliding-panel-color-hover;
-    }
   }
 }
 

--- a/source/assets/stylesheets/_navbar.scss
+++ b/source/assets/stylesheets/_navbar.scss
@@ -1,5 +1,6 @@
-$navbar-bg-color: #fff;
-$navbar-border: $base-border;
+$navbar-bg-color: tint($blue, 5%);
+$navbar-text-color: #fff;
+$navbar-border: solid 1px tint($navbar-bg-color, 15%);
 $navbar-height: 60px;
 $navbar-icon-size: 24px;
 $navbar-z-index: 9999;
@@ -9,8 +10,10 @@ $navbar-z-index: 9999;
   @include flex-direction(row);
   @include flex-wrap(nowrap);
   @include justify-content(space-between);
+  @include link-color($navbar-text-color);
+
   background-color: $navbar-bg-color;
-  border-bottom: $navbar-border;
+  color: $navbar-text-color;
   font-family: $heading-font-family;
   font-weight: normal;
   height: $navbar-height;

--- a/source/assets/stylesheets/base/_variables.scss
+++ b/source/assets/stylesheets/base/_variables.scss
@@ -16,7 +16,9 @@ $small-spacing: $base-spacing / 2;
 $base-z-index: 0;
 
 // Colors
-$blue: #1565c0;
+$light-blue: #bed7e2;
+$blue: #4b89a5;
+$dark-blue: #1e5c77;
 $dark-gray: #333;
 $medium-gray: #999;
 $light-gray: #ddd;


### PR DESCRIPTION
The new link-color() mixin simplifies the process of making links that
transition between two colors (a solid and a slightly transparent
version of the first), for use in places where the background-color is
something other than white. Going forward these mixins can live in the
global stylesheet until there are enough of them to justify being moved
to their own file.

Also, some color changes on the nav bar and sidebar.
