### PR TITLE
Rewrite Book::Chapter as Resource subclass

### DIFF
--- a/extensions/book/book_chapter.rb
+++ b/extensions/book/book_chapter.rb
@@ -3,17 +3,16 @@
 # the official Middleman-Blog extension:
 # https://github.com/middleman/middleman-blog/blob/master/lib/middleman-blog/blog_article.rb
 module Book
-  module Chapter
+  class Chapter < Middleman::Sitemap::Resource
     # @return [Book::BookExtension] reference to the parent BookExtension instance
     # (necessary for comparison between chapters)
-    attr_accessor :book
+    attr_reader :book
 
-    # self.extended callback
-    # This code runs every time the module is extended into an object instance
-    # def self.extended(base)
-    #   puts "Module #{self} is being used by #{base}"
-    #   puts base.metadata
-    # end
+    # Pass in a reference to the parent Book extension for later use
+    def initialize(store, path, source, book)
+      super(store, path, source)
+      @book = book
+    end
 
     # The title of the chapter, set in frontmatter
     # @return [String]
@@ -43,13 +42,13 @@ module Book
     end
 
     # Returns the next chapter object, or false if this is the last chapter
-    # @return [Middleman::Sitemap::Resource]
+    # @return [Book::Chapter]
     def next_chapter
       @book.chapters.find { |p| p.rank == self.rank + 1 }
     end
 
     # Returns the previous chapter object, or false if this is the first chapter
-    # @return [Middleman::Sitemap::Resource]
+    # @return [Book::Chapter]
     # TODO: fix this method, currently it always returns to the cover page
     def prev_chapter
       @book.chapters.find { |p| p.rank == self.rank - 1 }


### PR DESCRIPTION
Based on @tdrenyo's suggestion, this commit re-works how Book::Chapter
objects are represented. Instead of mixing in a module to
already-existing Resource objects, the new approach creates a custom
subclass of Middleman::Sitemap::Resource and replaces any resources
which possess `sort_order` metadata with instances of this class.

This seems to solve the problem caused by LiveReload events under the
previous approach: things would work fine initially but chapters would
"forget" that they had been extended with the additional module on
reload, causing some things to break.

One caveat of rolling your own Resource subclasses - make sure to pass
all the right data to them. In addition to the arguments provided to the
initialize method (store, path, and source file), it is important to
explicitly call the resource#add_metadata method and pass in a
correctly-formatted hash. The easiest way to do this was to just copy
the same hash from the original resource's metadata and pass it in after
initializing the Book::Chapter object.
